### PR TITLE
Mouse coordinates toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -301,6 +301,15 @@
             toggleRocks(newValue)
             model.globalState.showRocks = newValue
           }
+        },
+        { field: 'mouseCoordinatesToggle', type: 'toggle',
+          html: {
+            label: 'Mouse Coordinates'
+          },
+          onChange(newValue) {
+            toggleMouseCoordinates(newValue)
+            model.globalState.showMouseCOordaintes = newValue
+          }
         }
     ],
     onChange(event) {

--- a/index.html
+++ b/index.html
@@ -304,11 +304,10 @@
         },
         { field: 'mouseCoordinatesToggle', type: 'toggle',
           html: {
-            label: 'Mouse Coordinates'
+            label: 'Hide Mouse Coordinates'
           },
           onChange(newValue) {
             toggleMouseCoordinates(newValue)
-            model.globalState.showMouseCOordaintes = newValue
           }
         }
     ],

--- a/js/map.js
+++ b/js/map.js
@@ -384,6 +384,7 @@ function grid(g, x, y) {
     toggleMap(model.globalState.showMap)
     togglePithoi(model.globalState.showPithoi)
     toggleRocks(model.globalState.showRocks)
+    toggleMouseCoordinates(model.globalState.showMouseCoordinates)
   }
 
   //#endregion
@@ -687,7 +688,14 @@ function grid(g, x, y) {
     }
   }
 
-
+  function toggleMouseCoordinates(toggle) {
+    const coordinates = d3.select('#coordinates')
+    if (toggle) {
+      coordinates.style('color', 'transparent')
+    } else {
+      coordinates.style('color', 'black')
+    }
+  }
   
   // ID // What does this do?
   // chart.append("g")

--- a/js/map.js
+++ b/js/map.js
@@ -384,7 +384,6 @@ function grid(g, x, y) {
     toggleMap(model.globalState.showMap)
     togglePithoi(model.globalState.showPithoi)
     toggleRocks(model.globalState.showRocks)
-    toggleMouseCoordinates(model.globalState.showMouseCoordinates)
   }
 
   //#endregion


### PR DESCRIPTION
Added a mouse coordinate toggle button. Ended up not requiring much code. Changed button name to hide mouse coordinates, because coordinates are on by default and button is off by default. We can change this logic later. However, I think everything should be showing by default and the toggle button should be used to hide features. 